### PR TITLE
Remove mediafire.com from upload_domains.yaml

### DIFF
--- a/upload_domains.yaml
+++ b/upload_domains.yaml
@@ -36,4 +36,3 @@
 - app: Mediafire
   domains:
     - mediafireuserupload.com
-    - mediafire.com


### PR DESCRIPTION
Removed mediafire.com from the list of domains.